### PR TITLE
Configurable duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ Level the video is compressed for download via the internet. Value must be betwe
 
 Defaults to `9`.
 
+###### -t, --time
+The duration of the streaming video file in seconds.
+
+Defaults to `2`.
+
 ###### -l, --list-size
 The number of streaming video files included in the playlist.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The number of streaming video files included in the playlist.
 Defaults to `10`.
 
 ###### -s, --storage-size
-The number of streaming video files stored after they cycle out of the playlist. This is useful in cases where you want to look at previously recorded footage. The streaming video files are 2 seconds long so to have a 24-hour cycle of recorded video, specify `43200` (make sure to have enough storage space).
+The number of streaming video files stored after they cycle out of the playlist. This is useful in cases where you want to look at previously recorded footage. The streaming video files are 2 seconds long by default so to have a 24-hour cycle of recorded video, specify `43200` (make sure to have enough storage space).
 
 Defaults to `10`.
 
@@ -136,3 +136,7 @@ npx raspi-live --help
 raspi-live is only concerned with streaming video from the camera module and does not offer a playback solution.
 
 Browser support between the different streaming formats varies so in most cases a JavaScript playback library will be necessary. For more information on this, check out [Mozilla's article on the subject](https://developer.mozilla.org/en-US/docs/Web/Apps/Fundamentals/Audio_and_video_delivery/Live_streaming_web_audio_and_video).
+
+
+## Performance
+HLS and DASH inherently have latency baked into the technology. To reduce this, set the `time` option to 1 or .5 seconds and increase the list and storage size via the `list-size` and `storage-size` options. Ideally, there should be 12 seconds of video in the list and 50 seconds of video in storage.

--- a/README.md
+++ b/README.md
@@ -14,19 +14,16 @@ The server will start serving the streaming files on `/camera`. Point streaming 
 ## Usage
 ```
 $ raspi-live --help
+Usage: raspi-live [options] [command]
 
-  Usage: raspi-live [options] [command]
+self-contained raspberry pi video streaming server
 
-  self-contained raspberry pi video streaming server
+Options:
+  -v, --version    output the version number
+  -h, --help       output usage information
 
-  Options:
-
-    -v, --version    output the version number
-    -h, --help       output usage information
-
-  Commands:
-
-    start [options]  start streaming video from the raspberry pi camera module
+Commands:
+  start [options]  start streaming video from the raspberry pi camera module
 ```
 
 ### Options

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Defaults to `8080`.
 raspi-live only supports streaming video from the Raspberry Pi camera module. Here's a the official documentation on how to connect and configure it: https://www.raspberrypi.org/documentation/usage/camera/.
 
 ### FFmpeg
-raspi-live uses FFmpeg, a video conversion command-line utility, to process the streaming H.264 video that the Raspberry Pi camera module outputs. Here's how to install it on your Raspberry Pi:
+raspi-live uses FFmpeg, a video conversion command-line utility, to process the streaming H.264 video that the Raspberry Pi camera module outputs. Version 4.0 or higher is required. Here's how to install it on your Raspberry Pi:
 
 1. Download and configure FFmpeg via:
 ```

--- a/cli.js
+++ b/cli.js
@@ -7,13 +7,10 @@ const os = require('os');
 const info = require('./package.json');
 const server = require('./lib/server');
 
-// Coercion function for integers
-const int = (value) => parseInt(value, 10);
-
-// Coercion function for integer range
+// Coercion function for number range
 const range = (min, max, value, def) => {
   if (value < min || value > max) return def;
-  return parseInt(value, 10);
+  return Number(value);
 };
 
 process.title = 'raspi-live';
@@ -28,17 +25,17 @@ program
   .description('start streaming video from the raspberry pi camera module')
   .option('-d, --directory <directory>', 'streaming video file hosting location', `${os.homedir()}/camera`)
   .option('-f, --format <format>', 'video streaming format [hls, dash]', /^(hls|dash)$/i, 'hls')
-  .option('-w, --width <width>', 'video resolution width', int, 1280)
-  .option('-h, --height <height>', 'video resolution height', int, 720)
-  .option('-r, --framerate <fps>', 'video frames per second', int, 25)
+  .option('-w, --width <width>', 'video resolution width', Number, 1280)
+  .option('-h, --height <height>', 'video resolution height', Number, 720)
+  .option('-r, --framerate <fps>', 'video frames per second', Number, 25)
   .option('-x, --horizontal-flip', 'flip the camera horizontally')
   .option('-y, --vertical-flip', 'flip the camera vertically')
   .option('-c, --compression-level <compression-level>', 'compression level [0-9]', range.bind(null, 0, 9), 9)
-  .option('-t, --time <time>', 'duration of streaming files', int, 2)
-  .option('-l, --list-size <list-size>', 'number of streaming files in the playlist', int, 10)
-  .option('-s, --storage-size <storage-size>', 'number of streaming files for storage purposes', int, 10)
-  .option('-p, --port <port>', 'port number the server runs on', int, 8080)
-  .action(({ directory, format, width, height, framerate, horizontalFlip = false, verticalFlip = false, compressionLevel, listSize, storageSize, port }) => {
+  .option('-t, --time <time>', 'duration of streaming files', Number, 2)
+  .option('-l, --list-size <list-size>', 'number of streaming files in the playlist', Number, 10)
+  .option('-s, --storage-size <storage-size>', 'number of streaming files for storage purposes', Number, 10)
+  .option('-p, --port <port>', 'port number the server runs on', Number, 8080)
+  .action(({ directory, format, width, height, framerate, horizontalFlip = false, verticalFlip = false, compressionLevel, time, listSize, storageSize, port }) => {
     console.log('configuration:', directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, time, listSize, storageSize, port);
     server(directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, time, listSize, storageSize, port);
   });

--- a/cli.js
+++ b/cli.js
@@ -34,12 +34,13 @@ program
   .option('-x, --horizontal-flip', 'flip the camera horizontally')
   .option('-y, --vertical-flip', 'flip the camera vertically')
   .option('-c, --compression-level <compression-level>', 'compression level [0-9]', range.bind(null, 0, 9), 9)
+  .option('-t, --time <time>', 'duration of streaming files', int, 2)
   .option('-l, --list-size <list-size>', 'number of streaming files in the playlist', int, 10)
   .option('-s, --storage-size <storage-size>', 'number of streaming files for storage purposes', int, 10)
   .option('-p, --port <port>', 'port number the server runs on', int, 8080)
   .action(({ directory, format, width, height, framerate, horizontalFlip = false, verticalFlip = false, compressionLevel, listSize, storageSize, port }) => {
-    console.log('configuration:', directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, listSize, storageSize, port);
-    server(directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, listSize, storageSize, port);
+    console.log('configuration:', directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, time, listSize, storageSize, port);
+    server(directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, time, listSize, storageSize, port);
   });
 
 program.parse(process.argv);

--- a/lib/server.js
+++ b/lib/server.js
@@ -39,11 +39,11 @@ module.exports = (directory, format, width, height, framerate, horizontalFlip, v
       '-hls_delete_threshold',
       storageSize,
       '-hls_flags',
-      'split_by_time+delete_segments',
-      '-use_localtime',
+      'split_by_time+delete_segments+second_level_segment_index',
+      '-strftime',
       1,
       '-hls_segment_filename',
-      path.join(directory, '%s.m4s'),
+      path.join(directory, '%s-%%d.m4s'),
       '-hls_segment_type',
       'fmp4'
     ];
@@ -66,7 +66,7 @@ module.exports = (directory, format, width, height, framerate, horizontalFlip, v
       '-init_seg_name',
       'init.m4s',
       '-media_seg_name',
-      '$Time$.m4s'
+      '$Time$-$Number$.m4s'
     ];
 
     conversionStream

--- a/lib/server.js
+++ b/lib/server.js
@@ -13,7 +13,7 @@ module.exports = (directory, format, width, height, framerate, horizontalFlip, v
   if (fs.existsSync(directory) === false) fs.mkdirSync(directory);
 
   // Start the camera stream
-  const raspividOptions = ['-o', '-', '-t', '0', '-w', width, '-h', height, '-fps', framerate];
+  const raspividOptions = ['-o', '-', '-t', '0', '-w', width, '-h', height, '-fps', framerate, '-g', framerate];
   if (horizontalFlip) raspividOptions.push('-hf');
   if (verticalFlip) raspividOptions.push('-vf');
 
@@ -39,7 +39,7 @@ module.exports = (directory, format, width, height, framerate, horizontalFlip, v
       '-hls_delete_threshold',
       storageSize,
       '-hls_flags',
-      'delete_segments',
+      'split_by_time+delete_segments',
       '-use_localtime',
       1,
       '-hls_segment_filename',

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const spawn = require('child_process').spawn;
 const ffmpeg = require('fluent-ffmpeg');
 
-module.exports = (directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, listSize, storageSize, port) => {
+module.exports = (directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, time, listSize, storageSize, port) => {
   // Create the camera output directory if it doesn't already exist
   // Sync, because this is only run once at startup and everything depends on it
   if (fs.existsSync(directory) === false) fs.mkdirSync(directory);
@@ -32,6 +32,8 @@ module.exports = (directory, format, width, height, framerate, horizontalFlip, v
 
   if (format === 'hls') {
     const outputOptions = [
+      '-hls_time',
+      time,
       '-hls_list_size',
       listSize,
       '-hls_delete_threshold',
@@ -56,7 +58,7 @@ module.exports = (directory, format, width, height, framerate, horizontalFlip, v
   else if (format === 'dash') {
     const outputOptions = [
       '-seg_duration',
-      2,
+      time,
       '-window_size',
       listSize,
       '-extra_window_size',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raspi-live",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "self-contained raspberry pi video streaming server",
   "main": "cli.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "license": "MIT",
   "repository": "github:jaredpetersen/raspi-live",
   "dependencies": {
-    "commander": "^2.17.0",
+    "commander": "^2.19.0",
     "compression": "^1.7.3",
     "cors": "^2.8.4",
-    "express": "^4.16.3",
+    "express": "^4.16.4",
     "fluent-ffmpeg": "^2.1.2"
   }
 }


### PR DESCRIPTION
Added configurable clip duration via the `time` option.

Allowing for sub-second clip durations (for reduced latency) meant needing to change the output file names, which were previously in epoch time. Adjusting those file names required a new version of FFmpeg, hence the major version.