### PR TITLE
Upgraded commander, hopefully fixed a bug caused by help

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -40,6 +40,5 @@ program
     server(directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, time, listSize, storageSize, port);
   });
 
+program.helpOption('--help');
 program.parse(process.argv);
-
-if (!program.args.length) program.help();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "raspi-live",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -56,9 +56,9 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "commander": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.0.1.tgz",
-      "integrity": "sha512-IPF4ouhCP+qdlcmCedhxX4xiGBPyigb8v5NeUp+0LyhwLgxMqyp3S0vl7TAPfS/hiP7FC3caI/PB9lTmP8r1NA=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
     },
     "compressible": {
       "version": "2.0.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raspi-live",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "self-contained raspberry pi video streaming server",
   "author": "Jared Petersen <jaredtoddpetersen@gmail.com> (https://github.com/jaredpetersen/)",
   "license": "MIT",
@@ -16,7 +16,7 @@
   },
   "bin": "./cli.js",
   "dependencies": {
-    "commander": "^4.0.1",
+    "commander": "5.1.0",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "express": "^4.17.1",


### PR DESCRIPTION
Upgraded the commander dependency and hopefully fixed #32.

At the very least, #13 is fixed as `-h` no longer displays help.