### PR TITLE
Add support for specifying SSL certificate and key to run as HTTPS

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -35,9 +35,12 @@ program
   .option('-l, --list-size <list-size>', 'number of streaming files in the playlist', Number, 10)
   .option('-s, --storage-size <storage-size>', 'number of streaming files for storage purposes', Number, 10)
   .option('-p, --port <port>', 'port number the server runs on', Number, 8080)
-  .action(({ directory, format, width, height, framerate, horizontalFlip = false, verticalFlip = false, compressionLevel, time, listSize, storageSize, port }) => {
-    console.log('configuration:', directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, time, listSize, storageSize, port);
-    server(directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, time, listSize, storageSize, port);
+  .option('-S, --secure', 'run with credentials for HTTPS')
+  .option('-C, --certificate <file>', 'path to SSL certificate', '')
+  .option('-K, --key <file>', 'path to private key', '')
+  .action(({ directory, format, width, height, framerate, horizontalFlip = false, verticalFlip = false, compressionLevel, time, listSize, storageSize, port, secure = false, certificate, key}) => {
+    console.log('configuration:', directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, time, listSize, storageSize, port, secure, certificate, key);
+    server(directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, time, listSize, storageSize, port, secure, certificate, key);
   });
 
 program.helpOption('--help');

--- a/cli.js
+++ b/cli.js
@@ -38,9 +38,9 @@ program
   .option('-S, --secure', 'run with credentials for HTTPS')
   .option('-C, --certificate <file>', 'path to SSL certificate', '')
   .option('-K, --key <file>', 'path to private key', '')
-  .action(({ directory, format, width, height, framerate, horizontalFlip = false, verticalFlip = false, compressionLevel, time, listSize, storageSize, port, secure = false, certificate, key}) => {
-    console.log('configuration:', directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, time, listSize, storageSize, port, secure, certificate, key);
-    server(directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, time, listSize, storageSize, port, secure, certificate, key);
+  .action(({ directory, format, width, height, framerate, horizontalFlip = false, verticalFlip = false, compressionLevel, time, listSize, storageSize, port, secure = false, certificatePath, keyPath}) => {
+    console.log('configuration:', directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, time, listSize, storageSize, port, secure, certificatePath, keyPath);
+    server(directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, time, listSize, storageSize, port, secure, certificatePath, keyPath);
   });
 
 program.helpOption('--help');

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,7 +6,7 @@ const path = require('path');
 const fs = require('fs');
 const spawn = require('child_process').spawn;
 const ffmpeg = require('fluent-ffmpeg');
-var https = require('https');
+const https = require('https');
 
 module.exports = (
   directory,
@@ -22,8 +22,8 @@ module.exports = (
   storageSize,
   port,
   secure,
-  certificate,
-  key
+  certificatePath,
+  keyPath
 ) => {
   // Create the camera output directory if it doesn't already exist
   // Sync, because this is only run once at startup and everything depends on it
@@ -63,7 +63,7 @@ module.exports = (
       '-hls_segment_filename',
       path.join(directory, '%s-%%d.m4s'),
       '-hls_segment_type',
-      'fmp4',
+      'fmp4'
     ];
 
     conversionStream
@@ -83,7 +83,7 @@ module.exports = (
       '-init_seg_name',
       'init.m4s',
       '-media_seg_name',
-      '$Time$-$Number$.m4s',
+      '$Time$-$Number$.m4s'
     ];
 
     conversionStream
@@ -112,10 +112,12 @@ module.exports = (
   app.use(endpoint, express.static(directory));
 
   if (secure) {
-    https.createServer({
-      cert: fs.readFileSync(certificate, 'utf8'),
-      key: fs.readFileSync(key, 'utf8')
-    }, app).listen(port);
+    https
+      .createServer({
+        cert: fs.readFileSync(certificatePath, 'utf8'),
+        key: fs.readFileSync(keyPath, 'utf8')
+      }, app)
+      .listen(port);
   } else {
     app.listen(port);
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,8 +6,25 @@ const path = require('path');
 const fs = require('fs');
 const spawn = require('child_process').spawn;
 const ffmpeg = require('fluent-ffmpeg');
+var https = require('https');
 
-module.exports = (directory, format, width, height, framerate, horizontalFlip, verticalFlip, compressionLevel, time, listSize, storageSize, port) => {
+module.exports = (
+  directory,
+  format,
+  width,
+  height,
+  framerate,
+  horizontalFlip,
+  verticalFlip,
+  compressionLevel,
+  time,
+  listSize,
+  storageSize,
+  port,
+  secure,
+  certificate,
+  key
+) => {
   // Create the camera output directory if it doesn't already exist
   // Sync, because this is only run once at startup and everything depends on it
   if (fs.existsSync(directory) === false) fs.mkdirSync(directory);
@@ -46,7 +63,7 @@ module.exports = (directory, format, width, height, framerate, horizontalFlip, v
       '-hls_segment_filename',
       path.join(directory, '%s-%%d.m4s'),
       '-hls_segment_type',
-      'fmp4'
+      'fmp4',
     ];
 
     conversionStream
@@ -55,8 +72,7 @@ module.exports = (directory, format, width, height, framerate, horizontalFlip, v
       .inputOptions(['-re'])
       .outputOptions(outputOptions)
       .output(path.join(directory, 'livestream.m3u8'));
-  }
-  else if (format === 'dash') {
+  } else if (format === 'dash') {
     const outputOptions = [
       '-seg_duration',
       time,
@@ -67,7 +83,7 @@ module.exports = (directory, format, width, height, framerate, horizontalFlip, v
       '-init_seg_name',
       'init.m4s',
       '-media_seg_name',
-      '$Time$-$Number$.m4s'
+      '$Time$-$Number$.m4s',
     ];
 
     conversionStream
@@ -76,8 +92,7 @@ module.exports = (directory, format, width, height, framerate, horizontalFlip, v
       .inputOptions(['-re'])
       .outputOptions(outputOptions)
       .output(path.join(directory, 'livestream.mpd'));
-  }
-  else {
+  } else {
     kill(Error('unsupported format'));
   }
 
@@ -95,7 +110,15 @@ module.exports = (directory, format, width, height, framerate, horizontalFlip, v
   app.use(cors());
   app.use(compression({ level: compressionLevel }));
   app.use(endpoint, express.static(directory));
-  app.listen(port);
 
+  if (secure) {
+    https.createServer({
+      cert: fs.readFileSync(certificate, 'utf8'),
+      key: fs.readFileSync(key, 'utf8')
+    }, app).listen(port);
+  } else {
+    app.listen(port);
+  }
+  
   console.log('camera stream server started');
 };


### PR DESCRIPTION
Description:

The ability to specify a certificate (.crt) and private key (.key) allow the server to run securely. This is useful if you want to make your pi accessible outside of your network and stream via video.js, etc.

Testing:
- Ran with correct credentials and streamed video externally via domain supported by certificate
- Errors out when paths are incorrect
- verified without secure parameter, ran as normal
