### PR TITLE
Updated release workflow to put a 'v' prefix on tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ steps.changelog.outputs.version }}
+          tag_name: v${{ steps.changelog.outputs.version }}
           name: ${{ steps.changelog.outputs.version }}
           body: ${{ steps.changelog.outputs.changes }}
           draft: false

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -10,6 +10,11 @@ Build for Raspberry Pi:
 env GOOS=linux GOARCH=arm GOARM=6 go build ./cmd/raspilive
 ```
 
+Go install command:
+```zsh
+go install github.com/jaredpetersen/raspilive/cmd/raspilive
+```
+
 Run tests:
 ```zsh
 go test ./...


### PR DESCRIPTION
The release workflow needs to create tags prefixed with `v` otherwise GO complains about the versioning.

Also updated the dev docs with an example `go install` command.